### PR TITLE
Extend available space for the full name of employees on small portrait cards.

### DIFF
--- a/src/components/about/SmallPortraitCard.tsx
+++ b/src/components/about/SmallPortraitCard.tsx
@@ -4,7 +4,6 @@ import SocialMediaContacts from "./SocialMediaContacts";
 import { useRef, useState } from "react";
 import LargePortraitCard from "./LargePortraitCard";
 import Avatar from "./Avatar";
-import Link from "@docusaurus/Link";
 
 const contentStyle = {
   background: "white",

--- a/src/components/about/SubTeam.tsx
+++ b/src/components/about/SubTeam.tsx
@@ -15,7 +15,6 @@ export default function SubTeam({
               <div className="col">
                 <PopupPortrait
                   person={person}
-                 
                 />
               </div>
             </li>

--- a/src/components/about/styles.module.css
+++ b/src/components/about/styles.module.css
@@ -5,7 +5,7 @@
   color: var(--ifm-color-primary-p2);
   border-radius: 8px;
   box-shadow: 0px 0px 8px 1px #c8c8c7;
-  padding: var(--ifm-spacing-lg) var(--ifm-spacing-md);
+  padding: var(--ifm-spacing-lg) var(--ifm-spacing-xs);
   margin-bottom: var(--ifm-spacing-xl);
 }
 
@@ -14,6 +14,7 @@
   cursor: pointer; 
   text-decoration: #0000EE underline;
 }
+
 
 .value_text p {
   font-family: var(--ifm-font-family-roboto);
@@ -50,6 +51,7 @@ div .row {
   line-height: 24px;
   letter-spacing: 0.15px;
   margin: var(--ifm-spacing-xs) 0;
+  width: 100%
 }
 
 .small_card_position {


### PR DESCRIPTION
Extend width of the space available for the full name of employees on small portrait cards.
cc: @MMesch 
[Screencast from 02-09-2024 18:22:25.webm](https://github.com/user-attachments/assets/eb297754-b2db-429e-b54c-7283e02679cc)
